### PR TITLE
DIP17: Move `images` into the plugin repo

### DIFF
--- a/text/17-automated-build-and-submit-pipeline.md
+++ b/text/17-automated-build-and-submit-pipeline.md
@@ -52,9 +52,6 @@ owners = [
 # Optional: where your project/csproj is located within the repository.
 # If empty or unspecified, it will be assumed the project is in the root of the repository.
 project_path = "plugin"
-# Optional: where the images for the plugin (icon, plugin installer images, etc) are stored.
-# If empty or unspecified, it will be assumed that the images are in `/images` relative to the repository.
-images_path = "images"
 # The changelog for this version. Will be shown in-game, as well on the Goat Place Discord.
 changelog = "added Herobrine"
 # Optional: the version of the plugin. If not present, the `<Version>` specified in the `csproj`
@@ -94,6 +91,20 @@ This change would result in a new section being added to all `csproj`s that choo
             <Tag>Alarms</Tag>
             <Tag>Timer</Tag>
         </Tags>
+        <!--
+          These images will be processed (conversion, resizing, etc) and copied to PluginDist.
+          The images specified here are authoritative, and the images will always be sourced
+          from the repository.
+
+          The CI will also check that this section is present and points to valid images, so
+          that developers won't be able to submit plugins without images.
+        -->
+        <Images>
+            <Icon>../assets/images/icon@2x.png</Icon>
+            <Marketing>../assets/images/marketing/hero.png</Marketing>
+            <Marketing>../assets/images/marketing/screenshot1.png</Marketing>
+            <Marketing>../assets/images/marketing/screenshot2.png</Marketing>
+        </Images>
         <Hidden>False</Hidden>
     </DalamudPlugin>
 </ProjectExtensions>

--- a/text/17-automated-build-and-submit-pipeline.md
+++ b/text/17-automated-build-and-submit-pipeline.md
@@ -52,6 +52,9 @@ owners = [
 # Optional: where your project/csproj is located within the repository.
 # If empty or unspecified, it will be assumed the project is in the root of the repository.
 project_path = "plugin"
+# Optional: where the images for the plugin (icon, plugin installer images, etc) are stored.
+# If empty or unspecified, it will be assumed that the images are in `/images` relative to the repository.
+images_path = "images"
 # The changelog for this version. Will be shown in-game, as well on the Goat Place Discord.
 changelog = "added Herobrine"
 # Optional: the version of the plugin. If not present, the `<Version>` specified in the `csproj`
@@ -82,7 +85,6 @@ This change would result in a new section being added to all `csproj`s that choo
         <Name>GatherBuddy</Name>
         <Punchline>Simplify Gathering and Fishing.</Punchline>
         <Description>Adds commands to simplify gathering by finding nodes and fish and their locations via item name and a UI to keep track of special uptime and weather conditions.</Description>
-        <IconUrl>https://raw.githubusercontent.com/Ottermandias/GatherBuddy/main/images/icon.png</IconUrl>
         <Tags>
             <Tag>Gathering</Tag>
             <Tag>Fishing</Tag>
@@ -96,8 +98,6 @@ This change would result in a new section being added to all `csproj`s that choo
     </DalamudPlugin>
 </ProjectExtensions>
 ```
-
-(Note that the `IconUrl` obeys current rules for asset URLs. More work might be done on this in the future.)
 
 When submitting a plugin for the first time, the developer creates the file with the relevant details filled in, and creates a PR. A GitHub Action will retrieve the repository at the specified commit, attempt to build it through the GitHub Actions server pool and produce an artifact (using the DalamudPackager build step) that can be downloaded and loaded into Dalamud for testing by a goatcorp plugin reviewer. If accepted, the PR is merged, and the artifact is deployed to DalamudPlugins.
 


### PR DESCRIPTION
With the current implementation of DIP17, images are currently stored alongside the manifest. I think this doesn't really make sense if we're pulling the repo at a given revision anyway; we might as well pull the images from the repo.

This should make the submission process even more smooth, especially once `SamplePlugin` is updated for it.

Might need to add some words to make it explicit that the images are coming from the repo, if it's not obvious enough already.